### PR TITLE
change __FAILURE__ to MU_FAILURE

### DIFF
--- a/modules/SampleModule/main.c
+++ b/modules/SampleModule/main.c
@@ -148,7 +148,7 @@ static int SetupCallbacksForModule(IOTHUB_MODULE_CLIENT_LL_HANDLE iotHubModuleCl
     if (IoTHubModuleClient_LL_SetInputMessageCallback(iotHubModuleClientHandle, "input1", InputQueue1Callback, (void*)iotHubModuleClientHandle) != IOTHUB_CLIENT_OK)
     {
         printf("ERROR: IoTHubModuleClient_LL_SetInputMessageCallback(\"input1\")..........FAILED!\r\n");
-        ret = __FAILURE__;
+        ret = MU_FAILURE;
     }
     else
     {


### PR DESCRIPTION
The C SDK has updated macro_utils to define the macro __FAILURE__ as MU_FAILURE. As a result the current sample will fail to build unless the error return is changed to MU_FAILURE.